### PR TITLE
Fixed results folder not being changed by options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,6 @@ var gulp = require('gulp'),
     logFile = '/speedtest.txt',
     siteURL = settings.siteURL,
     sitePages = settings.sitePages,
-    resultsFolder = settings.resultsFolder,
     sitePagesUrls = [],
     htmlTestResults = [],
     folders = ['/content', '/content/images', '/content/styles'],
@@ -158,13 +157,13 @@ function htmltest() {
 };
 
 function copyResultsToResultsFolder() {
-    if (!fs.existsSync(resultsFolder)) { fs.mkdirSync(resultsFolder); }
+    if (!fs.existsSync(settings.resultsFolder)) { fs.mkdirSync(settings.resultsFolder); }
     folders.forEach(function(folder, index, array){
-        if (!fs.existsSync(resultsFolder+folder)) { fs.mkdirSync(resultsFolder+folder); }
+        if (!fs.existsSync(settings.resultsFolder+folder)) { fs.mkdirSync(settings.resultsFolder+folder); }
     });
     htmlFiles.forEach(function(file, index, array){
-        if (fs.existsSync(file)) { fs.unlinkSync(resultsFolder+file); }
-        fs.writeFileSync(resultsFolder+file, fs.readFileSync(prefix+file));
+        if (fs.existsSync(file)) { fs.unlinkSync(settings.resultsFolder+file); }
+        fs.writeFileSync(settings.resultsFolder+file, fs.readFileSync(prefix+file));
     });
 }
 
@@ -182,8 +181,8 @@ function performance(options) {
     siteURL = settings.siteURL;
     sitePages = settings.sitePages;
     copyResultsToResultsFolder();
-    logFile = resultsFolder+'/speedtest.txt';
-    fs.writeFile(resultsFolder+'/settings.txt', JSON.stringify(settings), function (err) {if (err) console.log(err);});
+    logFile = settings.resultsFolder+'/speedtest.txt';
+    fs.writeFile(settings.resultsFolder+'/settings.txt', JSON.stringify(settings), function (err) {if (err) console.log(err);});
     if (settings.runDevPerf) {
         GruntTasks(grunt);
         grunt.task.run('customdevperf');


### PR DESCRIPTION
Hi, great plugin! But I was experiencing the same issue as #36 and straight away looking at the code I could see that `resultsFolder` wasn't being updated.

I'm not sure why it was coded with a bunch of variables at the top. Everything should go into the settings object, and then that can be your one source of truth. So potentially look into why you have `siteURL`, `sitePages` and `sitePagesUrls` variables - even though these are not causing you issues now.

With these changes, I was able to run `gulp perf-tool` and get it to write to my `public` directory!