### PR TITLE
Fix link (href) of "View on Github" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                     Collect various information about your website and displays it in an easy-to-digest manner on the reports page
                 </h1>
                 <p class="promo-banner--desc">
-                    <a class="btn btn__cta">
+                    <a href="https://github.com/devbridge/Performance" class="btn btn__cta">
                         <i class="icon-github"></i> View on GitHub
                     </a>
                 </p>


### PR DESCRIPTION
The big "View on GitHub" button (anchor actually) was missing href to link it to the actual repo. Now uses the same as in `.page--nav`.

<img width="269" alt="screen shot 2016-07-07 at 18 04 50" src="https://cloud.githubusercontent.com/assets/1516059/16660202/b5475db6-446d-11e6-9143-dc9373693520.png">
