### PR TITLE
Update gulpfile to ensure URL not tainted with key

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,10 +72,11 @@ function speedtest() {
 
     results = { oldresults: { mobile: null, desktop: null }, newresults: {} },
     errorOccured = false,
-    finishedCount = 0;
-    if (settings.googleAPIKey) {
-        googleAPIURL += '&key='+settings.googleAPIKey;
-    }
+    finishedCount = 0,
+    key = settings.googleAPIKey ? '&key='+settings.googleAPIKey+'&url=' : '&url=';
+    // Configure with key
+    googleAPIURL += key;
+
 
     if (fs.existsSync(logFile)) {
         results = JSON.parse(fs.readFileSync(logFile, { encoding: 'Utf-8' }));


### PR DESCRIPTION
API key was being placed before URL and creating an incorrect URL structure:
 https://www.googleapis.com/pagespeedonline/v2/runPagespeed?filter_third_party_resources=false&locale=en_GB&screenshot=false&strategy=mobile&key=TheKeyValueshttps%3A%2F%2Fdomain.com%2Findex.php